### PR TITLE
Add metadata when discovering catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ ENV/
 
 # Custom stuff
 env.sh
+catalog.json
 config.json
 .autoenv.zsh
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_stella"],
     install_requires=[
-        "singer-python>=5.9.0",
+        "singer-python>=5.7.3",
         "PyJWT==1.7.1",
         "requests",
     ],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-stella",
-    version="0.1.1",
+    version="0.1.2",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/tap_stella/__init__.py
+++ b/tap_stella/__init__.py
@@ -31,13 +31,18 @@ def discover():
     raw_schemas = load_schemas()
     streams = []
     for stream_id, schema in raw_schemas.items():
-        # TODO: populate any metadata and stream's key properties here..
-        stream_metadata = []
         key_properties = ['uuid']
 
         replication_key = None
         if stream_id == 'qa':
             replication_key = 'sequence_id'
+
+        stream_metadata = metadata.get_standard_metadata(
+            schema=schema.to_dict(),
+            key_properties=key_properties,
+            valid_replication_keys=replication_key,
+            replication_method=None
+        )
 
         streams.append(
             CatalogEntry(


### PR DESCRIPTION
This is so that we can auto-select streams when generating catalogs per https://linear.app/pathlight/issue/PL-1086/automatically-select-all-streams-for-catalogs-in-tap-configs